### PR TITLE
[G2M] CLI - reduce index.js to just CLI, remove dual purpose of export lib

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,47 @@
+name: Default branch checks
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set Node.js version
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
+
+      - name: Cache Node Modules
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-build-${{ env.cache-name }}-
+            ${{ runner.OS }}-build-
+            ${{ runner.OS }}-
+
+      - run: yarn install
+      - run: yarn eslint .
+
+  commit-watch:
+    runs-on: ubuntu-latest
+    if: contains(github.event_name, 'pull_request')
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14.x
+
+      - run: npx @eqworks/commit-watch -b ${{ github.event.pull_request.base.sha }} -h ${{ github.event.pull_request.head.sha }} -v

--- a/README.md
+++ b/README.md
@@ -1,15 +1,20 @@
 # notify
 
-CLI for sending various notifications to various platforms.
-
-_currently only focuses on sending to Slack Incoming Webhooks_
-
-## Installation
-
-```bash
-npm i -g @eqworks/notify
-```
+CLI for sending various notifications (currently only through Slack incoming webhooks).
 
 ## Usage
 
-See `notify --help` for details.
+```shell
+% npm i -g @eqworks/notify
+% notify --help
+% # Or through `npx`
+% npx @eqworks/notify --help
+```
+
+To use the underlying library directly in supported JavaScript environments (local installation needed):
+
+```js
+const notify = require('@eqworks/notify/lib');
+// or
+import notify from '@eqworks/notify/lib';
+```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,17 @@ CLI for sending various notifications (currently only through Slack incoming web
 To use the underlying library directly in supported JavaScript environments (local installation needed):
 
 ```js
-const notify = require('@eqworks/notify/lib');
+// since v2.0.0
+const notify = require('@eqworks/notify/lib')
 // or
-import notify from '@eqworks/notify/lib';
+import notify from '@eqworks/notify/lib'
+```
+
+Note: pre-v2.0.0, the library export was dispatched from the package index:
+
+```js
+// For @eqworks/notify < v2.0.0
+const notify = require('@eqworks/notify')
+// or
+import notify from '@eqworks/notify'
 ```

--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 const lib = require('./lib')
 
-if (require.main === module) {
-  require('yargs')
+require('yargs')
   .usage('Usage: $0 <command> [options]')
   .command(
     'deployment <project>',
@@ -32,6 +31,3 @@ if (require.main === module) {
   .demandCommand()
   .help()
   .argv
-} else {
-  module.exports = lib
-}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/notify",
-  "version": "1.1.1-alpha.0",
+  "version": "2.0.0",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/notify",
-  "version": "1.1.0",
+  "version": "1.1.1-alpha.0",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
the reduction of `index.js` to be purely for CLI seems to fix npm 7+ issue with

```
npm ERR! could not determine executable to run
```